### PR TITLE
CL-95-Display-levels-on-profile-page

### DIFF
--- a/src/Components/CatCard.tsx
+++ b/src/Components/CatCard.tsx
@@ -11,6 +11,10 @@ export default function CatCard({ cat }: Props) {
 		<Card heading={cat.name}>
 			<div className="flex justify-between">
 				<img src={cat.picture_url ?? ''} alt={cat.name} className="w-20" />
+				<div>
+					<p>Level: {cat.battle_profile.level.toString()}</p>
+					<p>XP: {cat.battle_profile.xp.toString()}</p>
+				</div>
 				<p>{cat.description ?? 'A good kitty'}</p>
 			</div>
 		</Card>

--- a/src/Components/CatProfile.tsx
+++ b/src/Components/CatProfile.tsx
@@ -63,6 +63,7 @@ function CatProfile() {
 			updated_at: new Date().toISOString(),
 			created_at: new Date().toISOString(),
 			deleted_at: null,
+			battle_profile: catProfiles[0].battle_profile,
 		};
 		updateCatProfile(updatedProfile)
 			.then(() => {

--- a/src/Components/Styling/Card.tsx
+++ b/src/Components/Styling/Card.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export default function Card(props: Props) {
 	return (
-		<div className="bg-gray-200 p-5">
+		<div className="bg-gray-200 p-5 my-5">
 			<div className="border-b-2 border-blue-500 mb-5">
 				<H3>{props.heading}</H3>
 			</div>

--- a/src/Interfaces/CatFromAxios.ts
+++ b/src/Interfaces/CatFromAxios.ts
@@ -8,4 +8,8 @@ export default interface CatFromAxios {
 	updated_at: string;
 	created_at: string;
 	deleted_at: string | null;
+	battle_profile: {
+		level: Number;
+		xp: number;
+	};
 }


### PR DESCRIPTION
### Pull Request

**Title:** CL-95-Display-levels-on-profile-page

**Description:**

This pull request introduces enhancements to the profile page by displaying the cat's level and experience points (XP). The following changes have been made:

- Updated the CatFromAxios component to include the cat's level and XP data.
  
- Modified the CatCard component to present the cat's level and XP visually

- Implemented styling changes to ensure that the cards are visually distinct from one another.